### PR TITLE
Change banner background size to cover

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,5 +1,5 @@
 .banner {
-  background-size: 100%;
+  background-size: cover;
   background-position: center;
   padding: 150px 0;
   height: 100vh;


### PR DESCRIPTION
Changed banner background-size to cover from 100% so the image doesn't shrink when resizing the browser.